### PR TITLE
Update .vscode/tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,16 +8,10 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
+	"version": "2.0.0",
 
 	// we want to run npm
 	"command": "npm",
-
-	// the command is a shell script
-	"isShellCommand": true,
-
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
 
 	// we run the custom script "compile" as defined in package.json
 	"args": ["run", "compile", "--loglevel", "silent"],
@@ -26,5 +20,24 @@
 	"isWatching": true,
 
 	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+	"problemMatcher": "$tsc-watch",
+	"tasks": [
+		{
+			"label": "npm",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"compile",
+				"--loglevel",
+				"silent"
+			],
+			"isBackground": true,
+			"problemMatcher": "$tsc-watch",
+			"group": {
+				"_id": "build",
+				"isDefault": false
+			}
+		}
+	]
 }


### PR DESCRIPTION
When I open my clone of this repository in VS Code, it automatically updates `.vscode/tasks.json` from `"version": "0.1.0"` to `"version": "2.0.0"` as shown in the diff of this PR. I figured I'd submit it as a PR in case it's helpful, although I don't use VS Code tasks much so I can't tell whether this automatic update actually preserves the semantics.